### PR TITLE
Poetry CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Install test requirements
         run: poetry install --only test --no-root --no-interaction
       - name: Run tests
-        # Do NOT use `python -m pytest` here! That would import the live cose base instead of the installed one.
+        # Do NOT use `python -m pytest` here! That would import the live code base instead of the installed one.
         run: pytest -v -r a --import-mode=importlib --cov=epic.sql --cov-report html:cov_html --cov-report term
       - name: Archive library
         if: ${{ matrix.archive-artifacts }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,43 +30,31 @@ jobs:
         with:
           fetch-depth: 0
       - name: Setup python
-        id: setup-python
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install Poetry
         uses: snok/install-poetry@v1
         with:
-          virtualenvs-create: true
-          virtualenvs-in-project: true
-      - name: Load cached venv
-        id: cached-poetry-dependencies
-        uses: actions/cache@v4
-        with:
-          path: .venv
-          key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
-      - name: Install dependencies
-        if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
-        run: poetry install --no-interaction --no-root
-      - name: Run tests
-        run: poetry run pytest -v -r a --cov=epic.sql --cov-report html:cov_html --cov-report term
+          virtualenvs-create: false
       - name: Build library
-        if: ${{ matrix.archive-artifacts }}
-        run: poetry build
+        run: poetry build --format sdist
+      - name: Install library
+        run: python -m pip install dist/*.tar.gz
+      - name: Install test requirements
+        run: poetry install --only test --no-root --no-interaction
+      - name: Run tests
+        # Do NOT use `python -m pytest` here! That would import the live cose base instead of the installed one.
+        run: pytest -v -r a --import-mode=importlib --cov=epic.sql --cov-report html:cov_html --cov-report term
       - name: Archive library
         if: ${{ matrix.archive-artifacts }}
         uses: actions/upload-artifact@v4
         with:
           name: library
           path: dist/*.tar.gz
-      - name: Zip code coverage results
-        if: ${{ matrix.archive-artifacts }}
-        uses: montudor/action-zip@v1
-        with:
-          args: zip -qq -r cov_html.zip cov_html
       - name: Archive code coverage results
         if: ${{ matrix.archive-artifacts }}
         uses: actions/upload-artifact@v4
         with:
           name: code-coverage-report
-          path: cov_html.zip
+          path: cov_html

--- a/poetry.lock
+++ b/poetry.lock
@@ -994,4 +994,4 @@ bigquery = ["epic-jupyter", "google-api-core", "google-cloud-bigquery", "tqdm"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "e2ab9b0e78ead2f40ddf3c1151382e32ea62aca59b5a97c24e45d3cbca9d4db3"
+content-hash = "5b901c54ee5d9b1df6398feb153d474c3a0b2cad2aafc4a22285db70e1e26ec2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,16 +10,16 @@ packages = [{include = "epic"}]
 
 [tool.poetry.dependencies]
 python = "^3.10"
-pandas = "^2.2.3"
-epic-common = "^1.0.12"
-tqdm = {version = "^4.67.1", optional = true}
-google-api-core = {version = "^2.24.0", optional = true}
-google-cloud-bigquery = {version = "^3.27.0", optional = true}
-epic-jupyter = {version = "^1.0.5", optional = true}
+pandas = "*"
+epic-common = "*"
+tqdm = {version = "*", optional = true}
+google-api-core = {version = "*", optional = true}
+google-cloud-bigquery = {version = "*", optional = true}
+epic-jupyter = {version = "*", optional = true}
 
 [tool.poetry.group.test.dependencies]
-pytest = "^8.3.4"
-pytest-cov = "^6.0.0"
+pytest = "*"
+pytest-cov = "*"
 
 [tool.poetry.extras]
 bigquery = [


### PR DESCRIPTION
Updated CI so that we test the installed library and not the raw code.
- Poetry is installed with a flag to NOT create a virtual env. That means it'll work on the system's python.
- Build only `sdist`, no wheel.
- Install test deps using poetry, so that we don't need a separate requirements file for them. Here the lock file may be taken into account, but that's fine for test deps.
- I made sure that running `pytest` in this way tests the installed code:
  - On my machine, I broke the code after installation and made sure that `pytest` still runs successfully. Without the `--import-mode=importlib` or with `python -m pytest` it does not.
  - The coverage output prints out the full path of the covered files, and that path is in`site-packages`. This is verified on the output of the action that ran on Github as well.
- When uploading the `cov_html` dir, no need to ZIP. I read the documentation for `actions/upload-artifact`, and you can upload a folder. It gets zipped automatically by default.
- This whole thing works. You can check out the action output on the branch. That would be #12.

Also removed the versions from all the dependencies.